### PR TITLE
Click to Expand integration for iframe-based bbcodes.

### DIFF
--- a/build/addon-s9e.xml
+++ b/build/addon-s9e.xml
@@ -63,6 +63,16 @@
       <find>.bbCodeQuote iframe,</find>
       <replace>.bbCodeQuote iframe, .bbCodeQuote [data-s9e-mediaembed],</replace>
     </modification>
+    <modification action="str_replace" description="Click to Extend integration." enabled="1" execution_order="10" modification_key="s9e_quote_iframe_css" template="bb_code.css" >
+      <find><![CDATA[.bbCodeQuote iframe,]]></find>
+      <replace><![CDATA[.bbCodeQuote iframe[data-s9e-mediaembed]
+{
+	max-width: none;
+	max-height: none;
+}
+
+	$0]]></replace>
+    </modification>
   </public_template_modifications>
   <optiongroups>
     <group group_id="s9e" display_order="0" debug_only="0"/>


### PR DESCRIPTION
In Quotes, with the max-height set, iframe-based bbcodes are truncated rather than the adding the 'click to expand' link.

Preventing this css from applying at the start allows the existing 'click to expand' javascript to function, which was not apparent when I was experimenting in a browser.
